### PR TITLE
Wiki.deletedContribs(): bug fixes

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -2606,7 +2606,7 @@ public class Wiki implements Serializable
             throw new CredentialNotFoundException("Permission denied: not able to view deleted history");
 
         StringBuilder url = new StringBuilder(query);
-        url.append("list=alldeletedrevisions&adrprop=ids%7Cuser%7Cflags%7Csize%7Ccomment&adrlimit=max");
+        url.append("list=alldeletedrevisions&adrprop=ids%7Cuser%7Cflags%7Csize%7Ccomment%7Ctimestamp&adrlimit=max");
         if (reverse)
             url.append("&adrdir=newer");
         if (start != null)
@@ -2635,7 +2635,7 @@ public class Wiki implements Serializable
             adrcontinue = parseAttribute(response, "adrcontinue", 0);
 
             // parse
-            int x = response.indexOf("<deletedrevs>");
+            int x = response.indexOf("<alldeletedrevisions>");
             if (x < 0) // no deleted history
                 break;
             for (x = response.indexOf("<page ", x); x > 0; x = response.indexOf("<page ", ++x))


### PR DESCRIPTION
* Add `timestamp` property to query string (needed by `parseRevision()`)
* `<deletedrevs>` -> `<alldeletedrevisions>`