### PR TITLE
Upper-casing first letter in ns in 'normalize'

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -7392,6 +7392,8 @@ public class Wiki implements Serializable
             s = s.substring(1);
         if (s.isEmpty())
             return s;
+        if (wgCapitalLinks)
+            s = s.substring(0, 1).toUpperCase() + s.substring(1);
 
         int ns = namespace(s);
         // localize namespace names


### PR DESCRIPTION
Upper-casing first letter in a ns name in the normalize function as well. Otherwise e.g. "user:Example" does not normalise to "Користувач:Example" in a Ukrainian language wiki, while "User:Example" does.