### PR TITLE
[Wiki.java] constructTitleString: Actually limit to URL_LENGTH_LIMIT

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -1376,7 +1376,7 @@ public class Wiki implements Serializable
         Map[] info = new HashMap[pages.length];
         StringBuilder url = new StringBuilder(query);
         url.append("prop=info&intoken=edit%7Cwatch&inprop=protection%7Cdisplaytitle%7Cwatchers&titles=");
-        for (String temp : constructTitleString(pages, true))
+        for (String temp : constructTitleString(url.length(), pages, true))
         {
             String line = fetch(url.toString() + temp, "getPageInfo");
 
@@ -1635,7 +1635,7 @@ public class Wiki implements Serializable
         HashMap<String, String> pageTexts = new HashMap<>(2 * titles.length);
         String url = query + "prop=revisions&rvprop=content&titles=";
         
-        for (String chunk : constructTitleString(titles, true))
+        for (String chunk : constructTitleString(url.length(), titles, true))
         {
             String[] results = fetch(url + chunk, "getPageText").split("<page ");
 
@@ -2063,7 +2063,7 @@ public class Wiki implements Serializable
         url.append("action=purge");
         if (links)
             url.append("&forcelinkupdate");
-        for (String x : constructTitleString(titles, false))
+        for (String x : constructTitleString(0, titles, false))
             post(url.toString(), "titles=" + x, "purge");
         log(Level.INFO, "purge", "Successfully purged " + titles.length + " pages.");
     }
@@ -2240,7 +2240,6 @@ public class Wiki implements Serializable
     protected List<String>[] getTemplates(String[] titles, String template, int... ns) throws IOException
     {
         List<String>[] ret = new ArrayList[titles.length];
-        String[] titlestrings = constructTitleString(titles, true);
         
         StringBuilder url = new StringBuilder(query);
         url.append("prop=templates&tllimit=max");
@@ -2251,7 +2250,8 @@ public class Wiki implements Serializable
             url.append(encode(template, false));
         }
         url.append("&titles=");
-        
+
+        String[] titlestrings = constructTitleString(url.length() + "&tlcontinue=".length(), titles, true);
         for (String temp : titlestrings)
         {
             String tempurl = url.toString() + temp;
@@ -2517,7 +2517,7 @@ public class Wiki implements Serializable
             url.append("redirects");
         url.append("&titles=");
         String[] ret = new String[titles.length];
-        for (String blah : constructTitleString(titles, true))
+        for (String blah : constructTitleString(url.length(), titles, true))
         {
             String line = fetch(url.toString() + blah, "resolveRedirects");
             // expected form: <redirects><r from="Main page" to="Main Page"/>
@@ -4534,7 +4534,7 @@ public class Wiki implements Serializable
         String state = unwatch ? "unwatch" : "watch";
         if (watchlist == null)
             getRawWatchlist();
-        for (String titlestring : constructTitleString(titles, false))
+        for (String titlestring : constructTitleString(0, titles, false))
         {
             StringBuilder request = new StringBuilder("titles=");
             request.append(titlestring);
@@ -7585,13 +7585,14 @@ public class Wiki implements Serializable
 
     /**
      *  Cuts up a list of titles into batches for prop=X&amp;titles=Y type queries.
+     *  @param lengthBaseUrl the length of the url when no titles are present
      *  @param titles a list of titles.
      *  @param limit whether to apply the maximum URL size
      *  @return the titles ready for insertion into a URL
      *  @throws IOException if a network error occurs
      *  @since 0.29
      */
-    protected String[] constructTitleString(String[] titles, boolean limit) throws IOException
+    protected String[] constructTitleString(int lengthBaseUrl, String[] titles, boolean limit) throws IOException
     {
         // sort and remove duplicates per [[mw:API]]
         Set<String> set = new TreeSet<>();
@@ -7607,8 +7608,8 @@ public class Wiki implements Serializable
         int num = 1;
         for (int i = num; i < titlesEnc.length; i++)
         {
-            if (num < slowmax && // Assume the base url takes 400 bytes
-                buffer.length() + titleStringToken.length() + titlesEnc[i].length() < URL_LENGTH_LIMIT - 400)
+            if (num < slowmax &&
+                buffer.length() + titleStringToken.length() + titlesEnc[i].length() < URL_LENGTH_LIMIT - lengthBaseUrl)
             {
                 buffer.append(titleStringToken);
             }

--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -2251,7 +2251,8 @@ public class Wiki implements Serializable
         }
         url.append("&titles=");
 
-        String[] titlestrings = constructTitleString(url.length() + "&tlcontinue=".length(), titles, true);
+        // Also account for unknown lenght of tlcontinue's value
+        String[] titlestrings = constructTitleString(url.length() + "&tlcontinue=".length() + 1000, titles, true);
         for (String temp : titlestrings)
         {
             String tempurl = url.toString() + temp;

--- a/test/org/wikipedia/WikiUnitTest.java
+++ b/test/org/wikipedia/WikiUnitTest.java
@@ -580,7 +580,8 @@ public class WikiUnitTest
         String[] titleStrings = enWiki.constructTitleString(titles, false);
         for (String ts : titleStrings)
         {
-            assertTrue("constructTitleStringUrlLimit", ts.length() < enWiki.URL_LENGTH_LIMIT);
+            // Assume the base url is of length 400
+            assertTrue("constructTitleStringUrlLimit", ts.length() < enWiki.URL_LENGTH_LIMIT - 400);
         }
     }
 

--- a/test/org/wikipedia/WikiUnitTest.java
+++ b/test/org/wikipedia/WikiUnitTest.java
@@ -511,7 +511,7 @@ public class WikiUnitTest
                 "A91|A92|A93|A94|A95|A96|A97|A98", "UTF-8"),
             URLEncoder.encode("A99", "UTF-8")
         };
-        String[] actual = enWiki.constructTitleString(titles, false);
+        String[] actual = enWiki.constructTitleString(0, titles, false);
         assertArrayEquals("constructTitleString", expected, actual);
     }
     
@@ -577,11 +577,11 @@ public class WikiUnitTest
             "File:พระบามสมเด็จพระเจ้าอยู่หัวเปิดศาลาเหรียญ.jpg",
             "File:พระบาทสมเด็จพระเจ้าอยู่หัวเปิดศาลาเครื่องราช.jpg"
         };
-        String[] titleStrings = enWiki.constructTitleString(titles, false);
+        int lengthBaseUrl = (int)(Math.random() * 400);
+        String[] titleStrings = enWiki.constructTitleString(lengthBaseUrl, titles, false);
         for (String ts : titleStrings)
         {
-            // Assume the base url is of length 400
-            assertTrue("constructTitleStringUrlLimit", ts.length() < enWiki.URL_LENGTH_LIMIT - 400);
+            assertTrue("constructTitleStringUrlLimit", ts.length() <= enWiki.URL_LENGTH_LIMIT - lengthBaseUrl);
         }
     }
 


### PR DESCRIPTION
Instead of encoding the whole title string in the end, this does the encoding early (for each title separately).
