### PR TITLE
Parse <continue/> without making assumptions on its inner attributes

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -8017,29 +8017,30 @@ public class Wiki implements Comparable<Wiki>
             limit = querylimit;
         getparams.put("action", "query");
         List<T> results = new ArrayList<>(1333);
-        String xxcontinue = queryPrefix + "continue";
         String limitstring = queryPrefix + "limit";
         do
         {
             getparams.put(limitstring, String.valueOf(Math.min(limit - results.size(), max)));
             String line = makeApiCall(getparams, postparams, caller);
-            getparams.remove(xxcontinue);
-            getparams.remove("continue");
+            getparams.keySet().removeIf(param -> param.endsWith("continue"));
 
             // Continuation parameter has form:
             // <continue rccontinue="20170924064528|986351741" continue="-||" />
             if (line.contains("<continue "))
             {
                 int a = line.indexOf("<continue ") + 10;
-                int b = line.indexOf("/>", a);
-                String cont = line.substring(a, b);
-                getparams.put(xxcontinue, parseAttribute(cont, xxcontinue, 0));
-                getparams.put("continue", parseAttribute(cont, " continue", 0));
+                int b = line.indexOf(" />", a);
+                String cont = line.substring(a, b).trim();
+                for (String contAttr : cont.split("=\\S+"))
+                    // The above regex will leave a leading space in some attribute names,
+                    // which need to be trimmed before storing them in the parameter map.
+                    // This allows to detect the "continue" attribute (without prefix).
+                    getparams.put(contAttr.trim(), parseAttribute(cont, contAttr, 0));
             }
 
             parser.accept(line, results);
         }
-        while (getparams.containsKey(xxcontinue) && results.size() < limit);
+        while (getparams.containsKey("continue") && results.size() < limit);
         return results;
     }
 


### PR DESCRIPTION
The "modern" continuation mechanism (as opposed to `rawcontinue`) does not require API consumers to parse, select and process such attributes. Instead, passing them all on as they are to the next request should be enough. See also:

https://www.mediawiki.org/wiki/API:Query#Continuing_queries

The bug solved here is linked to the erroneous assumption that parsing `<prefix>continue` for list-type requests using the supplied prefix would be enough. This does not necessarily hold true for generator-based content queries, for instance:

`prop=revisions&rvprop=content&generator=embeddedin&geititle=Template:Foo`

shall return the following if the number of results *and* `geilimit` exceed `slowmax` (500 for bots):

`<continue rvcontinue="..." continue="..." />`

This behavior is due to the fact that results of content queries originating from a generator list are supplied in batches of `slowmax`. While consumers that benefit from higher limits usually retrieve up to
5000 results on a single `list=...` request, when it comes to fetching the wikitext with a generator, the MW API will split it in 10 batches of 500 items with a continuation element as shown above. Starting from the
*second* sequence of batches (from the 5001 result onwards), we'll see a `geicontinue` attribute, as expected by the previous implementation, *along with* the always present `rvcontinue`.