### PR TITLE
Adjust timestamps to UTC, fix referenced function in docs

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -8311,7 +8311,7 @@ public class Wiki implements Comparable<Wiki>
 
     /**
      *  Converts HTTP POST parameters to Strings. See {@link
-     *  #makeHTTPRequest(String, Map, String)} for the description.
+     *  #makeApiCall(Map, Map, String)} for the description.
      *  @param param the parameter to convert
      *  @return that parameter, as a String
      *  @throws UnsupportedOperationException if param is not a supported data type
@@ -8328,7 +8328,8 @@ public class Wiki implements Comparable<Wiki>
             return String.join("|", (String[])param);
         else if (param instanceof OffsetDateTime)
         {
-            OffsetDateTime date = (OffsetDateTime)param;
+            // MediaWiki API expects UTC timestamps
+            OffsetDateTime date = ((OffsetDateTime)param).withOffsetSameInstant(ZoneOffset.UTC);
             return date.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
         }
         else if (param instanceof Collection)


### PR DESCRIPTION
Wikis may override the default UTC time zone through site settings. In such cases the `edit(String, String, String, OffsetDateTime)` method assembles a timestamp from the current instant (for conflict check) with the following format:

`yyyy-MM-ddThh:mm:ss.sss+xx:xx`

Apparently, the last chunk (e.g. `+02:00` for UTC+2) is not well supported by MW. This error response was caught during a call to `edit` with a non-null fourth parameter (`OffsetDateTime`):

`<error code="badtimestamp_starttimestamp" info="Invalid value \"2018-09-12T19:12:46.578+02:00\"; for timestamp parameter \"starttimestamp\".">`

Works with `2018-09-12T17:12:46.578Z`, which is achieved in this patch. Tested on pl.wiktionary.org. See also:

https://www.mediawiki.org/wiki/API:Data_formats#Timestamps