### PR TITLE
Retrieve first element of parent list in single-page overloads of new vectorized-query methods

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -5290,7 +5290,7 @@ public class Wiki implements Comparable<Wiki>
      */
     public String[] whatLinksHere(String title, int... ns) throws IOException
     {
-        return whatLinksHere(Arrays.asList(title), false, ns).toArray(new String[0]);
+        return whatLinksHere(Arrays.asList(title), false, ns).get(0).toArray(new String[0]);
     }
 
     /**
@@ -5338,7 +5338,7 @@ public class Wiki implements Comparable<Wiki>
      */
     public String[] whatTranscludesHere(String title, int... ns) throws IOException
     {
-        return whatTranscludesHere(Arrays.asList(title), ns).toArray(new String[0]);
+        return whatTranscludesHere(Arrays.asList(title), ns).get(0).toArray(new String[0]);
     }
 
     /**


### PR DESCRIPTION
From https://github.com/MER-C/wiki-java/pull/165#issuecomment-476635444:

> @MER-C I'm getting a `java.lang.ArrayStoreException` whenever I call any of the single-page overloads after https://github.com/MER-C/wiki-java/pull/165/commits/dc5c46c8799a351318f4c88d9e448fe622d9fdd9 (`String[] whatLinksHere(String title, int... ns)` and `String[] whatTranscludesHere(String title, int... ns)`):
>
> ```java
> Wiki wiki = Wiki.newSession("pl.wiktionary.org");
> wiki.whatLinksHere(Arrays.asList("rescate"), false); // fine
> wiki.whatLinksHere("rescate"); // error
> ```
>
> ```
> Exception in thread "main" java.lang.ArrayStoreException
> 	at java.lang.System.arraycopy(Native Method)
> 	at java.util.Arrays.copyOf(Arrays.java:3213)
> 	at java.util.ArrayList.toArray(ArrayList.java:411)
>         ...
> ```
>
> Different example, more elaborate error output: `Exception in thread "main" java.lang.ArrayStoreException: arraycopy: element type mismatch: can not cast one of the elements of java.lang.Object[] to the type of the destination array, java.lang.String`.

Follows up https://github.com/MER-C/wiki-java/commit/dc5c46c8799a351318f4c88d9e448fe622d9fdd9.