### PR TITLE
Truncate timestamps to microsecond precision

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -3322,9 +3322,12 @@ public class Wiki implements Comparable<Wiki>
                 pro.append(value);
                 pro.append('|');
 
-                // https://phabricator.wikimedia.org/T16449
+                // https://www.mediawiki.org/wiki/Timestamp
+                // https://github.com/MER-C/wiki-java/issues/170
                 OffsetDateTime expiry = (OffsetDateTime)protectionstate.get(key + "expiry");
-                exp.append(expiry == null ? "never" : expiry.withOffsetSameInstant(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+                exp.append(expiry == null ? "never" : expiry.withOffsetSameInstant(ZoneOffset.UTC)
+                    .truncatedTo(ChronoUnit.MICROS)
+                    .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
                 exp.append('|');
             }
         });
@@ -7820,11 +7823,19 @@ public class Wiki implements Comparable<Wiki>
             OffsetDateTime odt = reverse ? earliest : latest;
             if (odt != null)
                 temp.put(requestType + "start",
-                    odt.withOffsetSameInstant(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+                    // https://www.mediawiki.org/wiki/Timestamp
+                    // https://github.com/MER-C/wiki-java/issues/170
+                    odt.withOffsetSameInstant(ZoneOffset.UTC)
+                        .truncatedTo(ChronoUnit.MICROS)
+                        .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
             odt = reverse ? latest : earliest;
             if (odt != null)
                 temp.put(requestType + "end",
-                    odt.withOffsetSameInstant(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+                    // https://www.mediawiki.org/wiki/Timestamp
+                    // https://github.com/MER-C/wiki-java/issues/170
+                    odt.withOffsetSameInstant(ZoneOffset.UTC)
+                        .truncatedTo(ChronoUnit.MICROS)
+                        .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
             return temp;
         }
 
@@ -8320,6 +8331,7 @@ public class Wiki implements Comparable<Wiki>
         {
             OffsetDateTime date = (OffsetDateTime)param;
             // https://www.mediawiki.org/wiki/Timestamp
+            // https://github.com/MER-C/wiki-java/issues/170
             return date.atZoneSameInstant(ZoneOffset.UTC)
                 .truncatedTo(ChronoUnit.MICROS)
                 .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);


### PR DESCRIPTION
This is a follow-up to https://github.com/MER-C/wiki-java/issues/170. I found a few more places where truncation is necessary, otherwise MW serves `badtimestamp` errors.

Suggestion: it is quite easy to mess up timestamp formatting upon conversion from `OffsetDateTime` into a string. Whereas #170 was an one-shot fix for all POST requests, which benefit from implicit Object-to-String conversion via [`convertToString`](https://github.com/MER-C/wiki-java/blob/64feb0f1097f5192e5a6f5a41457586112c2a0a4/src/org/wikipedia/Wiki.java#L8302-L8336), keep in mind that GET request params must be serialized by clients (cf. `Map` type parameters in `getparams` versus `postparams` in [`makeApiCall`](https://github.com/MER-C/wiki-java/blob/64feb0f1097f5192e5a6f5a41457586112c2a0a4/src/org/wikipedia/Wiki.java#L8089)). Therefore, whenever client code forgets to truncate timestamps prior to converting them into strings, underlying `makeApiCall` calls might return a `badtimestamp` error. I observed that `OffsetDateTime` instances may produce different strings on different machines: my application ran fine on WMF servers, but crashed because of this issue on my local PC.

To sum up: perhaps the `Map<String, String> getparams` stuff could be refurbished into a `Map<String, Object> getparams`and take advantage of `convertToString` as well?

 Also, consider refactorization of:

```java
odt.withOffsetSameInstant(ZoneOffset.UTC)
                    .truncatedTo(ChronoUnit.MICROS)
                    .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
```

A protected method could be useful for derived classes.