### PR TITLE
Make getPageInfo tell whether a page is a redirection or not

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -1638,6 +1638,7 @@ public class Wiki implements Comparable<Wiki>
      *    protection state} of the page. Does not cover implied protection
      *    levels (e.g. MediaWiki namespace).
      *  <li><b>exists</b>: (Boolean) whether the page exists
+     *  <li><b>redirect</b>: (Boolean) whether the page is a redirection
      *  <li><b>lastpurged</b>: (OffsetDateTime) when the page was last purged or
      *    <code>null</code> if the page does not exist
      *  <li><b>lastrevid</b>: (Long) the revid of the top revision or -1L if the
@@ -1738,6 +1739,7 @@ public class Wiki implements Comparable<Wiki>
 
                 tempmap.put("displaytitle", parseAttribute(item, "displaytitle", 0));
                 tempmap.put("timestamp", OffsetDateTime.now(timezone));
+                tempmap.put("redirect", item.contains("redirect=\"\""));
 
                 // number of watchers
                 if (item.contains("watchers=\""))


### PR DESCRIPTION
If I'm correct, you can only tell whether a page is a redirection or not by using the `Wiki.resolveRedirects` method, which returns a list of pages the arguments redirect to or, if not a redirection, the pages themselves. This is a bit cumbersome since the way to deal with it is to check for equality between titles:

```java
var titles = List.of(...);
var maybeRedirs = wiki.resolveRedirects(titles);

for (int i = 0; i < titles.size(); i++) {
    if (!maybeRedirs.get(i).equals(titles.get(i))) {
        // this is a redirection
    }
}
```

I think the `getPageInfo` method is a better fit.