### PR TITLE
Make Wiki.namespace ignore case in namespace beyond its first character

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -1808,8 +1808,10 @@ public class Wiki implements Comparable<Wiki>
         if (!title.contains(":"))
             return MAIN_NAMESPACE;
         title = title.replace("_", " ");
-        String namespace = title.substring(0, 1).toUpperCase(locale) + title.substring(1, title.indexOf(':'));
-        return namespaces.getOrDefault(namespace, MAIN_NAMESPACE);
+        String namespace = title.substring(0, title.indexOf(':'));
+        Map<String, Integer> tempmap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        tempmap.putAll(namespaces);
+        return tempmap.getOrDefault(namespace, MAIN_NAMESPACE);
     }
 
     /**

--- a/test/org/wikipedia/WikiTest.java
+++ b/test/org/wikipedia/WikiTest.java
@@ -158,6 +158,7 @@ public class WikiTest
     {
         assertEquals(Wiki.CATEGORY_NAMESPACE, enWiki.namespace("Category:CSD"), "en category");
         assertEquals(Wiki.CATEGORY_NAMESPACE, enWiki.namespace("category:CSD"), "en category lower case");
+        assertEquals(Wiki.CATEGORY_NAMESPACE, enWiki.namespace("CaTeGoRy:CSD"), "en category random inner case");
         assertEquals(Wiki.HELP_TALK_NAMESPACE, enWiki.namespace("Help talk:About"), "en help talk");
         assertEquals(Wiki.HELP_TALK_NAMESPACE, enWiki.namespace("help talk:About"), "en help talk lower case");
         assertEquals(Wiki.HELP_TALK_NAMESPACE, enWiki.namespace("help_talk:About"), "en help talk lower case underscore");


### PR DESCRIPTION
Apparently these work as expected:

```java
wiki.namespace("User:John Doe"); // = Wiki.USER_NAMESPACE
wiki.namespace("user:John Doe"); // = Wiki.USER_NAMESPACE
```

...but this doesn't:

```java
wiki.namespace("uSeR:John Doe"); // = Wiki.MAIN_NAMESPACE
```

This patch enables case-insensitive key lookup in the internal `namespaces` map (inspired by https://stackoverflow.com/a/22336599). Please note the original map is not altered because of https://github.com/MER-C/wiki-java/issues/64 (https://github.com/MER-C/wiki-java/commit/ab8137bbb24d4fe3cef1023c5de8b7ede9953503).