### PR TITLE
Remove bad index to start search from in `indexOf`

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -2087,7 +2087,7 @@ public class Wiki implements Comparable<Wiki>
                 String key = parseAttribute(results[i], isrevisions ? "revid" : "title", 0);
                 if (!results[i].contains("missing=\"\"") && !results[i].contains("texthidden=\"\""))
                 {
-                    int x = results[i].indexOf("<rev ", i);
+                    int x = results[i].indexOf("<rev ");
                     int y = results[i].indexOf('>', x) + 1;
                     // this </rev> tag is not present for empty pages/revisions
                     int z = results[i].indexOf("</rev>", y);


### PR DESCRIPTION
Fixed a bug in `getPageText`/`getText` caused by a misplaced second argument to `indexOf`. Can be reproduced when requesting a larger list of titles, in which case `i` would grow big enough to exceed the starting index of `<rev` and make XML scraping fail ([example](https://pl.wikipedia.org/w/index.php?diff=67908498&oldid=62667504&title=Dyskusja:Yakuza_4&diffmode=source)).