### PR TITLE
Guard against null pointers in `Wiki.exists`

### DIFF
--- a/src/org/wikipedia/Wiki.java
+++ b/src/org/wikipedia/Wiki.java
@@ -1989,7 +1989,7 @@ public class Wiki implements Comparable<Wiki>
         boolean[] ret = new boolean[titles.size()];
         List<Map<String, Object>> info = getPageInfo(titles);
         for (int i = 0; i < titles.size(); i++)
-            ret[i] = (Boolean)info.get(i).get("exists");
+            ret[i] = info.get(i) != null && (Boolean)info.get(i).get("exists");
         return ret;
     }
 

--- a/test/org/wikipedia/WikiTest.java
+++ b/test/org/wikipedia/WikiTest.java
@@ -355,8 +355,8 @@ public class WikiTest
     public void exists() throws Exception
     {
         List<String> titles = List.of("Main Page", "Tdkfgjsldf", "User:MER-C", 
-            "Wikipedia:Skfjdl", "Main Page", "Fish & chips");
-        boolean[] expected = new boolean[] { true, false, true, false, true, true };
+            "Wikipedia:Skfjdl", "Main Page", "Fish & chips", "[[illegal title]]");
+        boolean[] expected = new boolean[] { true, false, true, false, true, true, false };
         assertArrayEquals(expected, enWiki.exists(titles));
     }
 


### PR DESCRIPTION
`Wiki.getPageInfo` returns null for invalid titles.